### PR TITLE
fix(pip):change Werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests==2.27.1
+Werkzeug==2.2.2
 Flask==2.0.2
 gunicorn[gevent]
 gevent


### PR DESCRIPTION
## Description

The latest version of Werkzeug does not support Flask 2.0.2. Because of this, the deployment fails. 

## Motivation and Context

We need to add a specific version of the Werkzeug library tot the requirements.txt file in order do fix de deployment failures. Issue already exists: https://github.com/PaloAltoNetworks/cdl-decompress-proxy-sentinel-ingest/issues/8

## How Has This Been Tested?

I first deployed the app as is, and encountered errors in the App Service. After googling the error at https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr I changed the library to version 2.2.2 in the requirement.txt file, redeployed the app, which fixed the issue. 

## Screenshots (if appropriate)

NA

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
